### PR TITLE
fix nginx_strlen issue.

### DIFF
--- a/ngx_http_upstream_status_module.c
+++ b/ngx_http_upstream_status_module.c
@@ -163,7 +163,7 @@ ngx_http_upstream_status_writer(ngx_http_upstream_srv_conf_t *uscfp, ngx_http_re
             ngx_log_error(NGX_LOG_DEBUG, log, 0,
                        "reals: %V %d", &(upstream_round_robin_peer->name), up_down );
 
-            buf = ngx_create_temp_buf(r->pool, 20 + ngx_strlen(&(upstream_round_robin_peer->name)) );
+            buf = ngx_create_temp_buf(r->pool, 20 + (int)upstream_round_robin_peer->name.len );
             buf->last = ngx_sprintf(buf->pos, "<td>%V</td>",  &(upstream_round_robin_peer->name) );
             *out = append_buf_to_chain(r->pool, *out, buf);
 


### PR DESCRIPTION
I've fixed a small bug.

ngx_upstream_status creates a status page with following line.

buf = ngx_create_temp_buf(r->pool, 20 + ngx_strlen(&(upstream_round_robin_peer->name)) );

But ngx_strlen(&(upstream_round_robin_peer->name) always return "1".

Because upstream_round_robin_peer is a struct of ngx_str_t.

typedef struct {
    ngx_str_t   key;
    ngx_str_t   value;
} ngx_keyval_t;

and ngx_strlen() is following macro.
# define ngx_strlen(s)       strlen((const char *) s)

So that val of struct is always cast to const char \* and ngx_strlen() return "1".

Regards
